### PR TITLE
Fix the initial scale when setting a custom range

### DIFF
--- a/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane.cpp
+++ b/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane.cpp
@@ -620,7 +620,8 @@ namespace {
 
 void CartesianCoordinatePlane::setHorizontalRange( const QPair< qreal, qreal > & range )
 {
-    if ( !fuzzyCompare(d->horizontalMin, range.first) || !fuzzyCompare(d->horizontalMax, range.second) ) {
+    const bool bAutoAdjustHorizontalRange = d->autoAdjustHorizontalRangeToData < 100;
+    if ( !fuzzyCompare(d->horizontalMin, range.first) || !fuzzyCompare(d->horizontalMax, range.second) || bAutoAdjustHorizontalRange ) {
         d->autoAdjustHorizontalRangeToData = 100;
         d->horizontalMin = range.first;
         d->horizontalMax = range.second;
@@ -632,7 +633,8 @@ void CartesianCoordinatePlane::setHorizontalRange( const QPair< qreal, qreal > &
 
 void CartesianCoordinatePlane::setVerticalRange( const QPair< qreal, qreal > & range )
 {
-    if ( !fuzzyCompare(d->verticalMin, range.first) || !fuzzyCompare(d->verticalMax, range.second) ) {
+    const bool bAutoAdjustVerticalRange = d->autoAdjustVerticalRangeToData < 100;
+    if ( !fuzzyCompare(d->verticalMin, range.first) || !fuzzyCompare(d->verticalMax, range.second) || bAutoAdjustVerticalRange ) {
         d->autoAdjustVerticalRangeToData = 100;
         d->verticalMin = range.first;
         d->verticalMax = range.second;


### PR DESCRIPTION
If the range is automatically calculated and the user sets a custom one,
do not ignore the request even if the custom size is the same as we had
automatically calculated as wee also need to turn off the automatic
range calculation.