### PR TITLE
Fix line smoothing when the horizontal range is reversed

### DIFF
--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp
@@ -179,6 +179,8 @@ void NormalLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
     LabelPaintCache lpc;
     LineAttributesInfoList lineList;
 
+    const auto mainSplineDirection = plane->isHorizontalRangeReversed() ? ReverseSplineDirection : NormalSplineDirection;
+
     const int step = rev ? -1 : 1;
     const int end = rev ? -1 : columnCount;
     for ( int column = rev ? columnCount - 1 : 0; column != end; column += step ) {
@@ -292,7 +294,7 @@ void NormalLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
 
                         path.moveTo( a );
 
-                        addSplineChunkTo( path, tension, dataAt( row - 2 ), a, b, dataAt( row + 1 ) );
+                        addSplineChunkTo( path, tension, dataAt( row - 2 ), a, b, dataAt( row + 1 ), mainSplineDirection );
 
                         path.lineTo( d );
                         path.lineTo( c );

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLineDiagram_p.cpp
@@ -244,6 +244,11 @@ void PercentLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
     const int columnCount = compressor().modelDataColumns();
     const int rowCount = compressor().modelDataRows();
 
+    Q_ASSERT(dynamic_cast<CartesianCoordinatePlane*>(ctx->coordinatePlane()));
+    const auto plane = static_cast<CartesianCoordinatePlane*>(ctx->coordinatePlane());
+    const auto mainSplineDirection = plane->isHorizontalRangeReversed() ? ReverseSplineDirection : NormalSplineDirection;
+    const auto reverseSplineDirection = plane->isHorizontalRangeReversed() ? NormalSplineDirection : ReverseSplineDirection;
+
 // FIXME integrade column index retrieval to compressor:
     int maxFound = 0;
 //    {   // find the last column number that is not hidden
@@ -437,7 +442,7 @@ void PercentLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
                     const QPointF ptAfterNorthEast =
                         row < rowCount - 1 ? dataAt( stackedValuesTop, point.key + 2, 3 )
                                            : ptNorthEast;
-                    addSplineChunkTo( path, tension, ptBeforeNorthWest, ptNorthWest, ptNorthEast, ptAfterNorthEast );
+                    addSplineChunkTo( path, tension, ptBeforeNorthWest, ptNorthWest, ptNorthEast, ptAfterNorthEast, mainSplineDirection );
 
                     path.lineTo( ptNorthEast );
                     path.lineTo( ptSouthEast );
@@ -448,7 +453,7 @@ void PercentLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
                     const QPointF ptAfterSouthEast =
                         row < rowCount - 1 ? dataAt( stackedValuesBottom, point.key + 2, 3 )
                                            : ptSouthEast;
-                    addSplineChunkTo( path, tension, ptAfterSouthEast, ptSouthEast, ptSouthWest, ptBeforeSouthWest, ReverseSplineDirection );
+                    addSplineChunkTo( path, tension, ptAfterSouthEast, ptSouthEast, ptSouthWest, ptBeforeSouthWest, reverseSplineDirection );
 
                     areas << path;
                     laPreviousCell = laCell;

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLineDiagram_p.cpp
@@ -249,6 +249,11 @@ void StackedLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
     const int columnCount = compressor().modelDataColumns();
     const int rowCount = compressor().modelDataRows();
 
+    Q_ASSERT(dynamic_cast<CartesianCoordinatePlane*>(ctx->coordinatePlane()));
+    const auto plane = static_cast<CartesianCoordinatePlane*>(ctx->coordinatePlane());
+    const auto mainSplineDirection = plane->isHorizontalRangeReversed() ? ReverseSplineDirection : NormalSplineDirection;
+    const auto reverseSplineDirection = plane->isHorizontalRangeReversed() ? NormalSplineDirection : ReverseSplineDirection;
+
 // FIXME integrate column index retrieval to compressor:
 //    int maxFound = 0;
 //    {   // find the last column number that is not hidden
@@ -413,7 +418,7 @@ void StackedLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
                     const QPointF ptAfterNorthEast =
                         row < rowCount - 1 ? dataAt( stackedValuesTop, point.key + 2, 3 )
                                            : ptNorthEast;
-                    addSplineChunkTo( path, tension, ptBeforeNorthWest, ptNorthWest, ptNorthEast, ptAfterNorthEast );
+                    addSplineChunkTo( path, tension, ptBeforeNorthWest, ptNorthWest, ptNorthEast, ptAfterNorthEast, mainSplineDirection );
 
                     path.lineTo( ptNorthEast );
                     path.lineTo( ptSouthEast );
@@ -424,7 +429,7 @@ void StackedLineDiagram::paintWithSplines( PaintContext* ctx, qreal tension )
                     const QPointF ptAfterSouthEast =
                         row < rowCount - 1 ? dataAt( stackedValuesBottom, point.key + 2, 3 )
                                            : ptSouthEast;
-                    addSplineChunkTo( path, tension, ptAfterSouthEast, ptSouthEast, ptSouthWest, ptBeforeSouthWest, ReverseSplineDirection );
+                    addSplineChunkTo( path, tension, ptAfterSouthEast, ptSouthEast, ptSouthWest, ptBeforeSouthWest, reverseSplineDirection );
 
                     areas << path;
                     laPreviousCell = laCell;

--- a/src/KDChart/Cartesian/PaintingHelpers_p.h
+++ b/src/KDChart/Cartesian/PaintingHelpers_p.h
@@ -87,28 +87,28 @@ inline QPointF splineNode( qreal tension, QPointF before, QPointF current, QPoin
 enum SplineDirection { NormalSplineDirection, ReverseSplineDirection };
 
 inline QPair<QPointF, QPointF> splineChunk( qreal tension, QPointF before, QPointF a, QPointF b, QPointF after,
-                                            SplineDirection direction = NormalSplineDirection )
+                                            SplineDirection splineDirection )
 {
     QPointF nodeLeft = a;
     QPointF nodeRight = b;
 
     if ( !ISNAN( before.y() ) ) {
         nodeLeft = splineNode( tension, before, a, b,
-                direction == NormalSplineDirection ? LeftSplineNodePosition : RightSplineNodePosition );
+                splineDirection == NormalSplineDirection ? LeftSplineNodePosition : RightSplineNodePosition );
     }
 
     if ( !ISNAN( after.y() ) ) {
         nodeRight = splineNode( tension, a, b, after,
-                direction != NormalSplineDirection ? LeftSplineNodePosition : RightSplineNodePosition );
+                splineDirection != NormalSplineDirection ? LeftSplineNodePosition : RightSplineNodePosition );
     }
 
     return qMakePair( nodeLeft, nodeRight );
 }
 
 inline void addSplineChunkTo( QPainterPath& path, qreal tension, QPointF before, QPointF a, QPointF b, QPointF after,
-                              SplineDirection direction = NormalSplineDirection )
+                              SplineDirection splineDirection )
 {
-    const QPair<QPointF, QPointF> chunk = splineChunk( tension, before, a, b, after, direction );
+    const QPair<QPointF, QPointF> chunk = splineChunk( tension, before, a, b, after, splineDirection );
     path.cubicTo( chunk.first, chunk.second, b );
 }
 


### PR DESCRIPTION
When the graphs are mirrored horizontally, line smoothing created loops
because it calculated spline nodes as if the graph was left-to-right.