### PR TITLE
Fix Python bindings build

### DIFF
--- a/python/PyKDChart/KDGantt/typesystem_kdgantt.xml
+++ b/python/PyKDChart/KDGantt/typesystem_kdgantt.xml
@@ -3,6 +3,9 @@
     <load-typesystem name="typesystem_widgets.xml" generate="no"/>
 
     <namespace-type name="KDGantt" generate="no">
+        <modify-function signature="operator!=(KDGantt::Span,KDGantt::Span)" remove="all"/>
+        <modify-function signature="operator==(KDGantt::Span,KDGantt::Span)" remove="all"/>
+        
         <enum-type name="ItemDataRole" />
         <enum-type name="ItemType" />
     


### PR DESCRIPTION
With the new PySide2 version all global functions some of these function
need to be manually removed to avoid problems with python bindings
compilation.