### PR TITLE
Added missing export rules for QDebug operators

### DIFF
--- a/src/KDGantt/kdganttitemdelegate.h
+++ b/src/KDGantt/kdganttitemdelegate.h
@@ -87,7 +87,7 @@ protected:
 }
 
 #ifndef QT_NO_DEBUG_STREAM
-QDebug operator<<(QDebug dbg, KDGantt::ItemDelegate::InteractionState);
+KDGANTT_EXPORT QDebug operator<<(QDebug dbg, KDGantt::ItemDelegate::InteractionState);
 #endif
 
 #endif /* KDGANTTITEMDELEGATE_H */

--- a/src/KDGantt/kdganttstyleoptionganttitem.h
+++ b/src/KDGantt/kdganttstyleoptionganttitem.h
@@ -50,8 +50,8 @@ public:
 
 #ifndef QT_NO_DEBUG_STREAM
 
-QDebug operator<<(QDebug dbg, KDGantt::StyleOptionGanttItem::Position p);
-QDebug operator<<(QDebug dbg, const KDGantt::StyleOptionGanttItem &s);
+KDGANTT_EXPORT QDebug operator<<(QDebug dbg, KDGantt::StyleOptionGanttItem::Position p);
+KDGANTT_EXPORT QDebug operator<<(QDebug dbg, const KDGantt::StyleOptionGanttItem &s);
 
 #endif /* QT_NO_DEBUG_STREAM */
 


### PR DESCRIPTION
That fix python bindings build on windows