### PR TITLE
Fix some -Wdocumentation-deprecated-sync warnings

### DIFF
--- a/src/KDChart/Cartesian/KDChartBarDiagram.h
+++ b/src/KDChart/Cartesian/KDChartBarDiagram.h
@@ -60,7 +60,7 @@ public:
         Normal,
         Stacked,
         Percent,
-        Rows ///< @deprecated Use BarDiagram::setOrientation() instead
+        Rows Q_DECL_ENUMERATOR_DEPRECATED ///< @deprecated Use BarDiagram::setOrientation() instead
     };
 
     void setType(const BarType type);

--- a/src/KDChart/Cartesian/KDChartCartesianAxis.h
+++ b/src/KDChart/Cartesian/KDChartCartesianAxis.h
@@ -84,14 +84,14 @@ public:
          * Be aware that setting this value can lead to
          * collisions between axis labels and the title
          */
-    void setTitleSpace(qreal value);
+    Q_DECL_DEPRECATED void setTitleSpace(qreal value);
     /// \deprecated
-    qreal titleSpace() const;
+    Q_DECL_DEPRECATED qreal titleSpace() const;
 
     /// \deprecated \brief use setTitleTextAttributes() instead
-    void setTitleSize(qreal value);
+    Q_DECL_DEPRECATED void setTitleSize(qreal value);
     /// \deprecated
-    qreal titleSize() const;
+    Q_DECL_DEPRECATED qreal titleSize() const;
 
     void setTitleTextAttributes(const TextAttributes &a);
     /**

--- a/src/KDChart/Cartesian/KDChartCartesianGrid.h
+++ b/src/KDChart/Cartesian/KDChartCartesianGrid.h
@@ -97,10 +97,10 @@ private:
           * \param adjustUpper If true, the function adjusts the end value
           * so it matches the position of a grid line, if false the end value is
           * left as it is, in any case the value is adjusted for internal calculation only.
-          *
-          * \returns stepWidth: One of the values from the granularities
+          * \param stepWidth One of the values from the granularities
           * list, optionally multiplied by a positive (or negative, resp.)
-          * power of ten. subStepWidth: The matching width for sub-grid lines.
+          * power of ten.
+          * \param subStepWidth The matching width for sub-grid lines.
           */
     virtual void calculateStepWidth(
         qreal start, qreal end,

--- a/src/KDChart/KDChartAbstractDiagram.h
+++ b/src/KDChart/KDChartAbstractDiagram.h
@@ -95,7 +95,7 @@ public:
          * Called by the widget's sizeEvent. Adjust all internal structures,
          * that are calculated, dependending on the size of the widget.
          *
-         * @param area
+         * @param area Size of the widget
          */
     virtual void resize(const QSizeF &area) = 0;
 
@@ -195,7 +195,6 @@ public:
          * Set the coordinate plane associated with the diagram. This determines
          * how coordinates in value space are mapped into pixel space. The chart
          * takes ownership.
-         * @return The coordinate plane associated with the diagram.
          */
     virtual void setCoordinatePlane(AbstractCoordinatePlane *plane);
 
@@ -567,7 +566,7 @@ public:
          *
          * \see percentMode
          */
-    void setPercentMode(bool percent);
+    Q_DECL_DEPRECATED void setPercentMode(bool percent);
 
     /**
          * \brief Returns whether this diagram is drawn in percent mode.
@@ -609,7 +608,7 @@ public:
          * Sets the dataset dimension of the diagram. Using this method
          * is deprecated. Use the specific diagram types instead.
          */
-    void setDatasetDimension(int dimension);
+    Q_DECL_DEPRECATED void setDatasetDimension(int dimension);
 
 protected:
     void setDatasetDimensionInternal(int dimension);
@@ -648,7 +647,7 @@ protected:
          * d->paintDataValueTextsAndMarkers() instead
          * which also is taking care for showing your cell-specific comments, if any,
          */
-    virtual void paintDataValueTexts(QPainter *painter);
+    Q_DECL_DEPRECATED virtual void paintDataValueTexts(QPainter *painter);
     /**
          * \deprecated
          * This method is deprecated and provided for backward-compatibility only.
@@ -656,7 +655,7 @@ protected:
          * d->paintDataValueTextsAndMarkers() instead
          * which also is taking care for showing your cell-specific comments, if any,
          */
-    virtual void paintMarkers(QPainter *painter);
+    Q_DECL_DEPRECATED virtual void paintMarkers(QPainter *painter);
     void setAttributesModelRootIndex(const QModelIndex &);
     QModelIndex attributesModelRootIndex() const;
 
@@ -667,7 +666,7 @@ protected:
          * @return The value of the display role at the given row and column as a qreal.
          * @deprecated
          */
-    qreal valueForCell(int row, int column) const;
+    Q_DECL_DEPRECATED qreal valueForCell(int row, int column) const;
 
 Q_SIGNALS:
     /** Diagrams are supposed to emit this signal, when the layout of one

--- a/src/KDChart/Polar/KDChartAbstractPieDiagram.h
+++ b/src/KDChart/Polar/KDChartAbstractPieDiagram.h
@@ -55,9 +55,9 @@ public:
     qreal granularity() const;
 
     /** \deprecated Use PolarCoordinatePlane::setStartPosition( qreal degrees ) instead. */
-    void setStartPosition(int degrees);
+    Q_DECL_DEPRECATED void setStartPosition(int degrees);
     /** \deprecated Use qreal PolarCoordinatePlane::startPosition instead. */
-    int startPosition() const;
+    Q_DECL_DEPRECATED int startPosition() const;
 
     /** If this property is set, and if a pie's TextAttributes have no rotation set, its labels will
      * automatically be rotated according to the pie's angle.

--- a/src/KDChart/Polar/KDChartPolarDiagram.h
+++ b/src/KDChart/Polar/KDChartPolarDiagram.h
@@ -62,9 +62,9 @@ public:
     virtual PolarDiagram *clone() const;
 
     /** \deprecated Use PolarCoordinatePlane::setStartPosition( qreal degrees ) instead. */
-    void setZeroDegreePosition(int degrees);
+    Q_DECL_DEPRECATED void setZeroDegreePosition(int degrees);
     /** \deprecated Use qreal PolarCoordinatePlane::startPosition instead. */
-    int zeroDegreePosition() const;
+    Q_DECL_DEPRECATED int zeroDegreePosition() const;
 
     void setRotateCircularLabels(bool rotateCircularLabels);
     bool rotateCircularLabels() const;


### PR DESCRIPTION
Warnings like:

```
KDChart/src/KDChart/Cartesian/KDChartCartesianAxis.h:93:10: warning: declaration is marked with '\deprecated' command but does not have a deprecation attribute [-Wdocumentation-deprecated-sync]
    /// \deprecated
        ~^~~~~~~~~~
```