### PR TITLE
Make the AbstractThreeDAttributes::Private destructor virtual

### DIFF
--- a/src/KDChart/KDChartAbstractThreeDAttributes_p.h
+++ b/src/KDChart/KDChartAbstractThreeDAttributes_p.h
@@ -44,6 +44,7 @@ class AbstractThreeDAttributes::Private
 
 public:
     Private();
+    virtual ~Private() = default;
 
 private:
     bool enabled = false;


### PR DESCRIPTION
Otherwise ASAN is unhappy
```
=================================================================
==67335==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x6030008cf440 in thread T0:
    object passed to delete has wrong type:
    size of the allocated type:   32 bytes;
    size of the deallocated type: 24 bytes.
    #0 0x7fc2165c5d69 in operator delete(void*, unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x7fc2021baf71 in KDChart::AbstractThreeDAttributes::~AbstractThreeDAttributes() KDChart/KDChartAbstractThreeDAttributes.cpp:66
    #2 0x7fc2021bb599 in KDChart::ThreeDLineAttributes::~ThreeDLineAttributes() KDChart/KDChartThreeDLineAttributes.cpp:64
    #3 0x7fc20219136b in QtPrivate::QVariantValueHelper<KDChart::ThreeDLineAttributes>::metaType(QVariant const&) /usr/include/qt/QtCore/qvariant.h:749
    #4 0x7fc2021902b9 in QtPrivate::MetaTypeInvoker<QtPrivate::QVariantValueHelper<KDChart::ThreeDLineAttributes>, QVariant const&, KDChart::ThreeDLineAttributes>::invoke(QVariant const&) /usr/include/qt/QtCore/qvariant.h:116
    #5 0x7fc20218e6f9 in KDChart::ThreeDLineAttributes qvariant_cast<KDChart::ThreeDLineAttributes>(QVariant const&) /usr/include/qt/QtCore/qvariant.h:879
    #6 0x7fc20218c665 in KDChart::ThreeDLineAttributes QVariant::value<KDChart::ThreeDLineAttributes>() const /usr/include/qt/QtCore/qvariant.h:367
    #7 0x7fc2021e1735 in KDChart::LineDiagram::threeDLineAttributes(QModelIndex const&) const KDChart/Cartesian/KDChartLineDiagram.cpp:331
    #8 0x7fc202201a8c in threeDLineAttributes KDChart/Cartesian/PaintingHelpers_p.cpp:239
    #9 0x7fc202201de5 in KDChart::PaintingHelpers::paintElements(KDChart::AbstractDiagram::Private*, KDChart::PaintContext*, KDChart::LabelPaintCache const&, QVector<KDChart::LineAttributesInfo> const&) KDChart/Cartesian/PaintingHelpers_p.cpp:288
    #10 0x7fc202215cb9 in KDChart::NormalLineDiagram::paintWithLines(KDChart::PaintContext*) KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp:165
    #11 0x7fc202215291 in KDChart::NormalLineDiagram::paint(KDChart::PaintContext*) KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp:56
    #12 0x7fc2021e1fa3 in KDChart::LineDiagram::paint(KDChart::PaintContext*) KDChart/Cartesian/KDChartLineDiagram.cpp:429
    #13 0x7fc2021c3242 in KDChart::CartesianCoordinatePlane::paint(QPainter*) KDChart/Cartesian/KDChartCartesianCoordinatePlane.cpp:139
    #14 0x7fc2021836d5 in KDChart::AbstractArea::paintAll(QPainter&) KDChart/KDChartAbstractArea.cpp:141
    #15 0x7fc20215cc59 in KDChart::Chart::Private::paintAll(QPainter*) KDChart/KDChartChart.cpp:1123
    #16 0x7fc20215e740 in KDChart::Chart::paintEvent(QPaintEvent*) KDChart/KDChartChart.cpp:1441

0x6030008cf440 is located 0 bytes inside of 32-byte region [0x6030008cf440,0x6030008cf460)
allocated by thread T0 here:
    #0 0x7fc2165c4ca1 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7fc2021bb43e in KDChart::ThreeDLineAttributes::ThreeDLineAttributes() KDChart/KDChartThreeDLineAttributes.cpp:42
    #2 0x7fc202191325 in QtPrivate::QVariantValueHelper<KDChart::ThreeDLineAttributes>::metaType(QVariant const&) /usr/include/qt/QtCore/qvariant.h:745
    #3 0x7fc2021902b9 in QtPrivate::MetaTypeInvoker<QtPrivate::QVariantValueHelper<KDChart::ThreeDLineAttributes>, QVariant const&, KDChart::ThreeDLineAttributes>::invoke(QVariant const&) /usr/include/qt/QtCore/qvariant.h:116
    #4 0x7fc20218e6f9 in KDChart::ThreeDLineAttributes qvariant_cast<KDChart::ThreeDLineAttributes>(QVariant const&) /usr/include/qt/QtCore/qvariant.h:879
    #5 0x7fc20218c665 in KDChart::ThreeDLineAttributes QVariant::value<KDChart::ThreeDLineAttributes>() const /usr/include/qt/QtCore/qvariant.h:367
    #6 0x7fc2021e1735 in KDChart::LineDiagram::threeDLineAttributes(QModelIndex const&) const KDChart/Cartesian/KDChartLineDiagram.cpp:331
    #7 0x7fc202201a8c in threeDLineAttributes KDChart/Cartesian/PaintingHelpers_p.cpp:239
    #8 0x7fc202201de5 in KDChart::PaintingHelpers::paintElements(KDChart::AbstractDiagram::Private*, KDChart::PaintContext*, KDChart::LabelPaintCache const&, QVector<KDChart::LineAttributesInfo> const&) KDChart/Cartesian/PaintingHelpers_p.cpp:288
    #9 0x7fc202215cb9 in KDChart::NormalLineDiagram::paintWithLines(KDChart::PaintContext*) KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp:165
    #10 0x7fc202215291 in KDChart::NormalLineDiagram::paint(KDChart::PaintContext*) KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp:56
    #11 0x7fc2021e1fa3 in KDChart::LineDiagram::paint(KDChart::PaintContext*) KDChart/Cartesian/KDChartLineDiagram.cpp:429
    #12 0x7fc2021c3242 in KDChart::CartesianCoordinatePlane::paint(QPainter*) KDChart/Cartesian/KDChartCartesianCoordinatePlane.cpp:139
    #13 0x7fc2021836d5 in KDChart::AbstractArea::paintAll(QPainter&) KDChart/KDChartAbstractArea.cpp:141
    #14 0x7fc20215cc59 in KDChart::Chart::Private::paintAll(QPainter*) KDChart/KDChartChart.cpp:1123
    #15 0x7fc20215e740 in KDChart::Chart::paintEvent(QPaintEvent*) KDChart/KDChartChart.cpp:1441
```