### PR TITLE
Fix assert when there's no data to plot

### DIFF
--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp
@@ -136,7 +136,7 @@ void NormalLineDiagram::paintWithLines(PaintContext *ctx)
                                     Position::NorthWest, point.value);
 
                 // add line and area, if switched on and we have a current and previous value
-                if (!ISNAN(lastPoint.value)) {
+                if (!ISNAN(a.x()) && !ISNAN(a.y()) && !ISNAN(b.x()) && !ISNAN(b.y())) {
                     lineList.append(LineAttributesInfo(sourceIndex, a, b));
 
                     if (laCell.displayArea()) {


### PR DESCRIPTION
ASSERT: "divisor < 0 || divisor > 0" in file /d/qt/6/inst/include/QtCore/qpoint.h, line 266

The plane transformation matrix ended up with a -inf value,
so plane->translate(QPointF(lastPoint.key + offset, lastPoint.value)))
leads to NAN even if lastPoint.value is valid.

Fixed by replacing the ISNAN test on lastPoint.value with a test on
`a` and `b`, i.e. the final coordinates.