### PR TITLE
Added destructor for graphics items in KDGantt GraphicsScene::clearItems() method

### DIFF
--- a/src/KDGantt/kdganttgraphicsscene.cpp
+++ b/src/KDGantt/kdganttgraphicsscene.cpp
@@ -503,10 +503,10 @@ void GraphicsScene::clearItems()
         delete *it;
     }
     d->items.clear();
-    
+
     // Clear constraints
-    QList<QGraphicsItem*> items = d->q->items();
-    for(QGraphicsItem * item: items) {
+    QList<QGraphicsItem *> items = d->q->items();
+    for (QGraphicsItem *item : items) {
         d->q->removeItem(item);
         delete item;
     }

--- a/src/KDGantt/kdganttgraphicsscene.cpp
+++ b/src/KDGantt/kdganttgraphicsscene.cpp
@@ -506,10 +506,7 @@ void GraphicsScene::clearItems()
 
     // Clear constraints
     QList<QGraphicsItem *> items = d->q->items();
-    for (QGraphicsItem *item : items) {
-        d->q->removeItem(item);
-        delete item;
-    }
+    qDeleteAll(items);
 }
 
 void GraphicsScene::updateItems()

--- a/src/KDGantt/kdganttgraphicsscene.cpp
+++ b/src/KDGantt/kdganttgraphicsscene.cpp
@@ -498,12 +498,18 @@ GraphicsItem *GraphicsScene::findItem(const QPersistentModelIndex &idx) const
 
 void GraphicsScene::clearItems()
 {
-    // TODO constraints
     QHash<QPersistentModelIndex, GraphicsItem *>::const_iterator it = d->items.constBegin();
     for (; it != d->items.constEnd(); ++it) {
         delete *it;
     }
     d->items.clear();
+    
+    // Clear constraints
+    QList<QGraphicsItem*> items = d->q->items();
+    for(QGraphicsItem * item: items) {
+        d->q->removeItem(item);
+        delete item;
+    }
 }
 
 void GraphicsScene::updateItems()


### PR DESCRIPTION
Add code for removing old constraints that solves drawing dublicate connections problem in KDGantt graphics view + clang formatting