### PR TITLE
Gantt - use DateTimeScaleFormatter for default DayFormatter

### DIFF
--- a/src/KDGantt/kdganttdatetimegrid.cpp
+++ b/src/KDGantt/kdganttdatetimegrid.cpp
@@ -1065,13 +1065,16 @@ void DateTimeGrid::paintDayScaleHeader(QPainter *painter, const QRectF &headerRe
     class DayFormatter : public Private::DateTextFormatter
     {
     public:
+        DayFormatter() : Private::DateTextFormatter(), m_formatter(DateTimeScaleFormatter::Range::Day, QString::fromLatin1("ddd"))
+        {
+        }
         ~DayFormatter() override
         {
         }
 
         QString format(const QDateTime &dt) override
         {
-            return dt.toString(QString::fromLatin1("ddd")).left(1);
+            return m_formatter.format(dt);
         }
         QRect textRect(qreal x, qreal offset, qreal dayWidth, const QRectF &headerRect, const QDateTime &dt) override
         {
@@ -1081,6 +1084,7 @@ void DateTimeGrid::paintDayScaleHeader(QPainter *painter, const QRectF &headerRe
                           QSizeF(dayWidth, headerRect.height() / 2.0))
                 .toAlignedRect();
         }
+        DateTimeScaleFormatter m_formatter;
     };
     d->paintHeader(painter, headerRect, exposedRect, offset, widget, // General parameters
                    Private::HeaderDay, new DayFormatter); // Custom parameters

--- a/src/KDGantt/kdganttdatetimegrid.cpp
+++ b/src/KDGantt/kdganttdatetimegrid.cpp
@@ -1065,7 +1065,9 @@ void DateTimeGrid::paintDayScaleHeader(QPainter *painter, const QRectF &headerRe
     class DayFormatter : public Private::DateTextFormatter
     {
     public:
-        DayFormatter() : Private::DateTextFormatter(), m_formatter(DateTimeScaleFormatter::Range::Day, QString::fromLatin1("ddd"))
+        DayFormatter()
+            : Private::DateTextFormatter()
+            , m_formatter(DateTimeScaleFormatter::Range::Day, QString::fromLatin1("ddd"))
         {
         }
         ~DayFormatter() override


### PR DESCRIPTION
The code originally hard-coded to use localized `ddd` format to get the day of week name and uses its first character for displaying. This will cause issue if the language is not English.

For example, when using Chinese language, the day-of-week name will be "周一", "周二", "周三" and so on, the current implementation will result all the grid says "周" and user will have no idea about what's the actual day-of-week the day is:

![image](https://github.com/KDAB/KDChart/assets/10095765/01a4f002-bd2c-4e36-b032-63a2c943b84a)

To reproduce this issue, set the locale/language to `zh_CN`, launch the Ganttlegend demo, then click `Zoom > Zoom Out` from the menu. You can also notice the week name is normal before you click the "Zoom Out" menu action.

This patch switch to use `DateTimeScaleFormatter` as what the default (auto) behavior uses) which doesn't have this issue.

![image](https://github.com/KDAB/KDChart/assets/10095765/ee9dc7b4-9485-4cc8-8c14-ffd3ce40cf78)

I'm not sure if it's the correct fix so feel free to update this patch directly if preferred. I think something similar to [ICU's `EEEEE` format](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#:~:text=or%20EEE%0AEEEE-,EEEEE,-EEEEEE) should be used but it seems Qt itself doesn't support this sort of syntax. Not sure if there are other ways to do so.
