### PR TITLE
Fix alignment of labels in legends

### DIFF
--- a/src/KDChart/KDChartLayoutItems.cpp
+++ b/src/KDChart/KDChartLayoutItems.cpp
@@ -479,8 +479,7 @@ void KDChart::TextLayoutItem::paint(QPainter *painter)
     }
     painter->setFont(f);
 
-    QSize innerSize = unrotatedTextSize();
-    QRectF rect = QRectF(QPointF(0, 0), innerSize);
+    QRectF rect = mRect;
     rect.translate(-rect.center());
     painter->translate(mRect.center());
     painter->rotate(mAttributes.rotation());


### PR DESCRIPTION
Previously, KDChart would calculate a bounding rectangle for the text and then center that in the space provided for the text. This meant that setting a text alignment essentially had no effect. Now KDChart will take advantage of all available space for aligning text.
