### PR TITLE
Add spacing to legend text

### DIFF
--- a/src/KDChart/KDChartLegend.cpp
+++ b/src/KDChart/KDChartLegend.cpp
@@ -1052,6 +1052,7 @@ void Legend::Private::flowHDatasetItems(Legend *q)
     const int allowedWidth = q->areaGeometry().width();
 
     auto *currentLine = new QHBoxLayout;
+    currentLine->setSpacing(3);
     int mainLayoutRow = 1;
     layout->addItem(currentLine, mainLayoutRow++, /*column*/ 0,
                     /*rowSpan*/ 1, /*columnSpan*/ 5, Qt::AlignLeft | Qt::AlignVCenter);
@@ -1073,6 +1074,7 @@ void Legend::Private::flowHDatasetItems(Legend *q)
                          << allowedWidth;
 #endif
                 currentLine = new QHBoxLayout;
+                currentLine->setSpacing(3);
                 layout->addItem(currentLine, mainLayoutRow++, /*column*/ 0,
                                 /*rowSpan*/ 1, /*columnSpan*/ 5, Qt::AlignLeft | Qt::AlignVCenter);
             } else {


### PR DESCRIPTION
After the changes introduced in #52 made left-aligning legend text possible, it became evident that there was no spacing applied between the legend label and the legend indicator. Therefore, I've applied 3px of spacing to remedy the issue.
