### PR TITLE
Standardize project to KDAB copyright policy

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,22 +5,22 @@ Source: https://www.github.com/KDAB/KDChart
 
 #misc source code
 Files: *.qrc *.ui *.xml *.kdx *.kxs *.conf *.csv *.cht *.map *.bat
-Copyright: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #artwork
 Files: images/*.png docs/api/*.png examples/*/*.png images/*.svg src/KDChart/resources/*.svg
-Copyright: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc documentation
 Files: *md *.txt CHANGES src/TODO *.html docs/manual/*.pdf
-Copyright: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc config files
 Files: .pre-commit-config.yaml .codespellrc .krazy .cmake-format.py .clang-format .clazy .gitignore .mdlrc .mdlrc.rb .pep8 .pylintrc appveyor.yml docs/api/Doxyfile.cmake distro/*
-Copyright: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: BSD-3-Clause
 
 #3rdparty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 License
 =======
-The KD Chart Software is Copyright 2001-2023 Klarälvdalens Datakonsult AB (KDAB),
-and is available under the terms of the MIT license.
+The KD Chart Software is © Klarälvdalens Datakonsult AB (KDAB), and is
+available under the terms of the MIT license.
 
 See the full license text in the LICENSES folder.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Please submit your contributions or issue reports to our GitHub space at
 
 ## License
 
-The KD Chart Software is Copyright 2001-2023 Klarälvdalens Datakonsult AB (KDAB),
-and is available under the terms of the [MIT](LICENSES/MIT.txt) license.
+The KD Chart Software is © Klarälvdalens Datakonsult AB (KDAB), and is
+available under the terms of the [MIT](LICENSES/MIT.txt) license.
 
 Contact KDAB at <info@kdab.com> for any licensing queries.
 

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/api/footer.html
+++ b/docs/api/footer.html
@@ -1,7 +1,7 @@
     <hr>
     <div style="float: left;">
       <img src="kdab-logo-22x22.png">
-      <font style="font-weight: bold;">&copy; 2001-2023 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
+      <font style="font-weight: bold;">&copy; 2001 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
       <br>
 	    "The Qt, C++ and OpenGL Experts"<br>
 	    <a href="https://www.kdab.com/">https://www.kdab.com/</a>

--- a/examples/Axis/Chart/CMakeLists.txt
+++ b/examples/Axis/Chart/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Axis/Chart/main.cpp
+++ b/examples/Axis/Chart/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Chart/mainwindow.cpp
+++ b/examples/Axis/Chart/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Chart/mainwindow.h
+++ b/examples/Axis/Chart/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Labels/AdjustedCartesianAxis.cpp
+++ b/examples/Axis/Labels/AdjustedCartesianAxis.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Labels/AdjustedCartesianAxis.h
+++ b/examples/Axis/Labels/AdjustedCartesianAxis.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Labels/CMakeLists.txt
+++ b/examples/Axis/Labels/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Axis/Labels/main.cpp
+++ b/examples/Axis/Labels/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Labels/mainwindow.cpp
+++ b/examples/Axis/Labels/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Labels/mainwindow.h
+++ b/examples/Axis/Labels/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Parameters/CMakeLists.txt
+++ b/examples/Axis/Parameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Axis/Parameters/main.cpp
+++ b/examples/Axis/Parameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Parameters/mainwindow.cpp
+++ b/examples/Axis/Parameters/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Parameters/mainwindow.h
+++ b/examples/Axis/Parameters/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Axis/Widget/CMakeLists.txt
+++ b/examples/Axis/Widget/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Axis/Widget/main.cpp
+++ b/examples/Axis/Widget/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Background/CMakeLists.txt
+++ b/examples/Background/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Background/main.cpp
+++ b/examples/Background/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Bars/Advanced/CMakeLists.txt
+++ b/examples/Bars/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Bars/Advanced/main.cpp
+++ b/examples/Bars/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Bars/Advanced/mainwindow.cpp
+++ b/examples/Bars/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Bars/Advanced/mainwindow.h
+++ b/examples/Bars/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Bars/Parameters/CMakeLists.txt
+++ b/examples/Bars/Parameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Bars/Parameters/main.cpp
+++ b/examples/Bars/Parameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Bars/Simple/CMakeLists.txt
+++ b/examples/Bars/Simple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Bars/Simple/main.cpp
+++ b/examples/Bars/Simple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/DataValueTexts/CMakeLists.txt
+++ b/examples/DataValueTexts/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/DataValueTexts/main.cpp
+++ b/examples/DataValueTexts/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DataValueTexts/mainwindow.cpp
+++ b/examples/DataValueTexts/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DataValueTexts/mainwindow.h
+++ b/examples/DataValueTexts/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DrawIntoPainter/CMakeLists.txt
+++ b/examples/DrawIntoPainter/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/DrawIntoPainter/framewidget.cpp
+++ b/examples/DrawIntoPainter/framewidget.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DrawIntoPainter/framewidget.h
+++ b/examples/DrawIntoPainter/framewidget.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DrawIntoPainter/main.cpp
+++ b/examples/DrawIntoPainter/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DrawIntoPainter/mainwindow.cpp
+++ b/examples/DrawIntoPainter/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/DrawIntoPainter/mainwindow.h
+++ b/examples/DrawIntoPainter/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/EmptyValues/CMakeLists.txt
+++ b/examples/EmptyValues/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/EmptyValues/main.cpp
+++ b/examples/EmptyValues/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/EmptyValues/mainwindow.cpp
+++ b/examples/EmptyValues/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/EmptyValues/mainwindow.h
+++ b/examples/EmptyValues/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/legend_example/CMakeLists.txt
+++ b/examples/Gantt/legend_example/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Gantt/legend_example/entrydelegate.cpp
+++ b/examples/Gantt/legend_example/entrydelegate.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/legend_example/entrydelegate.h
+++ b/examples/Gantt/legend_example/entrydelegate.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/legend_example/entrydialog.cpp
+++ b/examples/Gantt/legend_example/entrydialog.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/legend_example/entrydialog.h
+++ b/examples/Gantt/legend_example/entrydialog.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/legend_example/main.cpp
+++ b/examples/Gantt/legend_example/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/legend_example/mainwindow.cpp
+++ b/examples/Gantt/legend_example/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/legend_example/mainwindow.h
+++ b/examples/Gantt/legend_example/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/project/CMakeLists.txt
+++ b/examples/Gantt/project/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Gantt/project/main.cpp
+++ b/examples/Gantt/project/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/project/mainwindow.cpp
+++ b/examples/Gantt/project/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/project/mainwindow.h
+++ b/examples/Gantt/project/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/project/projectmodel.cpp
+++ b/examples/Gantt/project/projectmodel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Gantt/project/projectmodel.h
+++ b/examples/Gantt/project/projectmodel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Grids/CartesianGrid/CMakeLists.txt
+++ b/examples/Grids/CartesianGrid/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Grids/CartesianGrid/main.cpp
+++ b/examples/Grids/CartesianGrid/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Grids/PolarGrid/CMakeLists.txt
+++ b/examples/Grids/PolarGrid/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Grids/PolarGrid/main.cpp
+++ b/examples/Grids/PolarGrid/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Grids/PolarGrid/mainwindow.cpp
+++ b/examples/Grids/PolarGrid/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Grids/PolarGrid/mainwindow.h
+++ b/examples/Grids/PolarGrid/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/HeadersFooters/Advanced/CMakeLists.txt
+++ b/examples/HeadersFooters/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/HeadersFooters/Advanced/main.cpp
+++ b/examples/HeadersFooters/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/HeadersFooters/Advanced/mainwindow.cpp
+++ b/examples/HeadersFooters/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/HeadersFooters/Advanced/mainwindow.h
+++ b/examples/HeadersFooters/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/HeadersFooters/HeadersFootersParameters/CMakeLists.txt
+++ b/examples/HeadersFooters/HeadersFootersParameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/HeadersFooters/HeadersFootersParameters/main.cpp
+++ b/examples/HeadersFooters/HeadersFootersParameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/HeadersFooters/HeadersFootersSimple/CMakeLists.txt
+++ b/examples/HeadersFooters/HeadersFootersSimple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/HeadersFooters/HeadersFootersSimple/main.cpp
+++ b/examples/HeadersFooters/HeadersFootersSimple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendAdvanced/CMakeLists.txt
+++ b/examples/Legends/LegendAdvanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Legends/LegendAdvanced/derivedaddlegenddialog.cpp
+++ b/examples/Legends/LegendAdvanced/derivedaddlegenddialog.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendAdvanced/derivedaddlegenddialog.h
+++ b/examples/Legends/LegendAdvanced/derivedaddlegenddialog.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendAdvanced/main.cpp
+++ b/examples/Legends/LegendAdvanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendAdvanced/mainwindow.cpp
+++ b/examples/Legends/LegendAdvanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendAdvanced/mainwindow.h
+++ b/examples/Legends/LegendAdvanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendOverDiagram/CMakeLists.txt
+++ b/examples/Legends/LegendOverDiagram/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Legends/LegendOverDiagram/main.cpp
+++ b/examples/Legends/LegendOverDiagram/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendParameters/CMakeLists.txt
+++ b/examples/Legends/LegendParameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Legends/LegendParameters/main.cpp
+++ b/examples/Legends/LegendParameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Legends/LegendSimple/CMakeLists.txt
+++ b/examples/Legends/LegendSimple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Legends/LegendSimple/main.cpp
+++ b/examples/Legends/LegendSimple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/LeveyJennings/Simple/CMakeLists.txt
+++ b/examples/LeveyJennings/Simple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/LeveyJennings/Simple/main.cpp
+++ b/examples/LeveyJennings/Simple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/Advanced/CMakeLists.txt
+++ b/examples/Lines/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Lines/Advanced/main.cpp
+++ b/examples/Lines/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/Advanced/mainwindow.cpp
+++ b/examples/Lines/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/Advanced/mainwindow.h
+++ b/examples/Lines/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/AreaPerCell/CMakeLists.txt
+++ b/examples/Lines/AreaPerCell/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Lines/AreaPerCell/main.cpp
+++ b/examples/Lines/AreaPerCell/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/Parameters/CMakeLists.txt
+++ b/examples/Lines/Parameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Lines/Parameters/main.cpp
+++ b/examples/Lines/Parameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/PointChart/CMakeLists.txt
+++ b/examples/Lines/PointChart/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Lines/PointChart/main.cpp
+++ b/examples/Lines/PointChart/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/PointChart/mainwindow.cpp
+++ b/examples/Lines/PointChart/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/PointChart/mainwindow.h
+++ b/examples/Lines/PointChart/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/PointWidget/CMakeLists.txt
+++ b/examples/Lines/PointWidget/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Lines/PointWidget/main.cpp
+++ b/examples/Lines/PointWidget/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Lines/SimpleLineWidget/CMakeLists.txt
+++ b/examples/Lines/SimpleLineWidget/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Lines/SimpleLineWidget/main.cpp
+++ b/examples/Lines/SimpleLineWidget/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ModelView/HidingData/CMakeLists.txt
+++ b/examples/ModelView/HidingData/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/ModelView/HidingData/main.cpp
+++ b/examples/ModelView/HidingData/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ModelView/HidingData/mainwindow.cpp
+++ b/examples/ModelView/HidingData/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ModelView/HidingData/mainwindow.h
+++ b/examples/ModelView/HidingData/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ModelView/TableView/CMakeLists.txt
+++ b/examples/ModelView/TableView/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/ModelView/TableView/main.cpp
+++ b/examples/ModelView/TableView/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ModelView/TableView/mainwindow.cpp
+++ b/examples/ModelView/TableView/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/ModelView/TableView/mainwindow.h
+++ b/examples/ModelView/TableView/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/NoValues/CMakeLists.txt
+++ b/examples/NoValues/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/NoValues/main.cpp
+++ b/examples/NoValues/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/NoValues/mainwindow.cpp
+++ b/examples/NoValues/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/NoValues/mainwindow.h
+++ b/examples/NoValues/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Pie/Advanced/CMakeLists.txt
+++ b/examples/Pie/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Pie/Advanced/main.cpp
+++ b/examples/Pie/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Pie/Advanced/mainwindow.cpp
+++ b/examples/Pie/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Pie/Advanced/mainwindow.h
+++ b/examples/Pie/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Pie/Parameters/CMakeLists.txt
+++ b/examples/Pie/Parameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Pie/Parameters/main.cpp
+++ b/examples/Pie/Parameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Pie/Simple/CMakeLists.txt
+++ b/examples/Pie/Simple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Pie/Simple/main.cpp
+++ b/examples/Pie/Simple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plane/AdjustedBoundaries/CMakeLists.txt
+++ b/examples/Plane/AdjustedBoundaries/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plane/AdjustedBoundaries/main.cpp
+++ b/examples/Plane/AdjustedBoundaries/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plane/OverlayedPlanes/CMakeLists.txt
+++ b/examples/Plane/OverlayedPlanes/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plane/OverlayedPlanes/main.cpp
+++ b/examples/Plane/OverlayedPlanes/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plane/OverlayedPlanes/mainwindow.cpp
+++ b/examples/Plane/OverlayedPlanes/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plane/OverlayedPlanes/mainwindow.h
+++ b/examples/Plane/OverlayedPlanes/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Advanced/CMakeLists.txt
+++ b/examples/Plotter/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plotter/Advanced/main.cpp
+++ b/examples/Plotter/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BigDataset/CMakeLists.txt
+++ b/examples/Plotter/BigDataset/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plotter/BigDataset/MainWidget.cpp
+++ b/examples/Plotter/BigDataset/MainWidget.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BigDataset/MainWidget.h
+++ b/examples/Plotter/BigDataset/MainWidget.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BigDataset/Model.cpp
+++ b/examples/Plotter/BigDataset/Model.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BigDataset/Model.h
+++ b/examples/Plotter/BigDataset/Model.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BigDataset/main.cpp
+++ b/examples/Plotter/BigDataset/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BubbleChart/CMakeLists.txt
+++ b/examples/Plotter/BubbleChart/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plotter/BubbleChart/main.cpp
+++ b/examples/Plotter/BubbleChart/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BubbleChart/mainwindow.cpp
+++ b/examples/Plotter/BubbleChart/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/BubbleChart/mainwindow.h
+++ b/examples/Plotter/BubbleChart/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Isometric/CMakeLists.txt
+++ b/examples/Plotter/Isometric/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plotter/Isometric/main.cpp
+++ b/examples/Plotter/Isometric/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Logarithmic/CMakeLists.txt
+++ b/examples/Plotter/Logarithmic/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plotter/Logarithmic/main.cpp
+++ b/examples/Plotter/Logarithmic/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Simple/CMakeLists.txt
+++ b/examples/Plotter/Simple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plotter/Simple/main.cpp
+++ b/examples/Plotter/Simple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Timeline/CMakeLists.txt
+++ b/examples/Plotter/Timeline/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Plotter/Timeline/main.cpp
+++ b/examples/Plotter/Timeline/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Timeline/timeaxis.cpp
+++ b/examples/Plotter/Timeline/timeaxis.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Timeline/timeaxis.h
+++ b/examples/Plotter/Timeline/timeaxis.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Timeline/timechartmodel.cpp
+++ b/examples/Plotter/Timeline/timechartmodel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Plotter/Timeline/timechartmodel.h
+++ b/examples/Plotter/Timeline/timechartmodel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Polar/Advanced/CMakeLists.txt
+++ b/examples/Polar/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Polar/Advanced/main.cpp
+++ b/examples/Polar/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Polar/Advanced/mainwindow.cpp
+++ b/examples/Polar/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Polar/Advanced/mainwindow.h
+++ b/examples/Polar/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Polar/Parameters/CMakeLists.txt
+++ b/examples/Polar/Parameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Polar/Parameters/main.cpp
+++ b/examples/Polar/Parameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Polar/Simple/CMakeLists.txt
+++ b/examples/Polar/Simple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Polar/Simple/main.cpp
+++ b/examples/Polar/Simple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/RealTime/CMakeLists.txt
+++ b/examples/RealTime/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/RealTime/main.cpp
+++ b/examples/RealTime/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/SharedAbscissa/SeparateDiagrams/CMakeLists.txt
+++ b/examples/SharedAbscissa/SeparateDiagrams/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/SharedAbscissa/SeparateDiagrams/main.cpp
+++ b/examples/SharedAbscissa/SeparateDiagrams/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/SharedAbscissa/SeparateDiagrams/mainwindow.cpp
+++ b/examples/SharedAbscissa/SeparateDiagrams/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/SharedAbscissa/SeparateDiagrams/mainwindow.h
+++ b/examples/SharedAbscissa/SeparateDiagrams/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Sql/CMakeLists.txt
+++ b/examples/Sql/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Sql/main.cpp
+++ b/examples/Sql/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Stock/Advanced/CMakeLists.txt
+++ b/examples/Stock/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Stock/Advanced/main.cpp
+++ b/examples/Stock/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Stock/Advanced/mainwindow.cpp
+++ b/examples/Stock/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Stock/Advanced/mainwindow.h
+++ b/examples/Stock/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/TernaryCharts/Advanced/CMakeLists.txt
+++ b/examples/TernaryCharts/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/TernaryCharts/Advanced/main.cpp
+++ b/examples/TernaryCharts/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/TernaryCharts/Advanced/mainwindow.cpp
+++ b/examples/TernaryCharts/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/TernaryCharts/Advanced/mainwindow.h
+++ b/examples/TernaryCharts/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Widget/Advanced/CMakeLists.txt
+++ b/examples/Widget/Advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Widget/Advanced/main.cpp
+++ b/examples/Widget/Advanced/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Widget/Advanced/mainwindow.cpp
+++ b/examples/Widget/Advanced/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Widget/Advanced/mainwindow.h
+++ b/examples/Widget/Advanced/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Widget/Parameters/CMakeLists.txt
+++ b/examples/Widget/Parameters/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Widget/Parameters/main.cpp
+++ b/examples/Widget/Parameters/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Widget/Simple/CMakeLists.txt
+++ b/examples/Widget/Simple/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Widget/Simple/main.cpp
+++ b/examples/Widget/Simple/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/Keyboard/CMakeLists.txt
+++ b/examples/Zoom/Keyboard/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Zoom/Keyboard/main.cpp
+++ b/examples/Zoom/Keyboard/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/Keyboard/mainwindow.cpp
+++ b/examples/Zoom/Keyboard/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/Keyboard/mainwindow.h
+++ b/examples/Zoom/Keyboard/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/Keyboard/zoomwidget.cpp
+++ b/examples/Zoom/Keyboard/zoomwidget.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/Keyboard/zoomwidget.h
+++ b/examples/Zoom/Keyboard/zoomwidget.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/ScrollBars/CMakeLists.txt
+++ b/examples/Zoom/ScrollBars/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/Zoom/ScrollBars/main.cpp
+++ b/examples/Zoom/ScrollBars/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/ScrollBars/mainwindow.cpp
+++ b/examples/Zoom/ScrollBars/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/Zoom/ScrollBars/mainwindow.h
+++ b/examples/Zoom/ScrollBars/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/CMakeLists.txt
+++ b/examples/demo/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/demo/axissettings.cpp
+++ b/examples/demo/axissettings.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/axissettings.h
+++ b/examples/demo/axissettings.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/colorslider.cpp
+++ b/examples/demo/colorslider.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/colorslider.h
+++ b/examples/demo/colorslider.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/datasetsettings.cpp
+++ b/examples/demo/datasetsettings.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/datasetsettings.h
+++ b/examples/demo/datasetsettings.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/datavaluesettings.cpp
+++ b/examples/demo/datavaluesettings.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/datavaluesettings.h
+++ b/examples/demo/datavaluesettings.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/diagramsettings.cpp
+++ b/examples/demo/diagramsettings.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/diagramsettings.h
+++ b/examples/demo/diagramsettings.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/diagramtypedialog.cpp
+++ b/examples/demo/diagramtypedialog.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/diagramtypedialog.h
+++ b/examples/demo/diagramtypedialog.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/gradientdialog.cpp
+++ b/examples/demo/gradientdialog.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/gradientdialog.h
+++ b/examples/demo/gradientdialog.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/main.cpp
+++ b/examples/demo/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/mainwindow.cpp
+++ b/examples/demo/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/demo/mainwindow.h
+++ b/examples/demo/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/tools/TableModel.cpp
+++ b/examples/tools/TableModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/tools/TableModel.h
+++ b/examples/tools/TableModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/tools/tools_export.h
+++ b/examples/tools/tools_export.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/features/kdchart.prf
+++ b/features/kdchart.prf
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/kdablibfakes/include/KDABLibFakes
+++ b/kdablibfakes/include/KDABLibFakes
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/kdablibfakes/src/KDABLibFakes.h
+++ b/kdablibfakes/src/KDABLibFakes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/kdchart.pri
+++ b/kdchart.pri
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/PyKDChart/CMakeLists.txt
+++ b/python/PyKDChart/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/PyKDChart/KDGantt/CMakeLists.txt
+++ b/python/PyKDChart/KDGantt/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/PyKDChart/KDGantt/kdgantt_global.h
+++ b/python/PyKDChart/KDGantt/kdgantt_global.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/python/PyKDChart/__init__.py.cmake
+++ b/python/PyKDChart/__init__.py.cmake
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/apireview/entrydelegate.py
+++ b/python/examples-qt6/apireview/entrydelegate.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/apireview/entrydialog.py
+++ b/python/examples-qt6/apireview/entrydialog.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/apireview/main.py
+++ b/python/examples-qt6/apireview/main.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/apireview/mainwindow.py
+++ b/python/examples-qt6/apireview/mainwindow.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/apireview/ui_entrydialog.py
+++ b/python/examples-qt6/apireview/ui_entrydialog.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/apireview/ui_mainwindow.py
+++ b/python/examples-qt6/apireview/ui_mainwindow.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/customconstraints/main.py
+++ b/python/examples-qt6/customconstraints/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/gfxview/main.py
+++ b/python/examples-qt6/gfxview/main.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/headers/main.py
+++ b/python/examples-qt6/headers/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/listview/main.py
+++ b/python/examples-qt6/listview/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/reorder/main.py
+++ b/python/examples-qt6/reorder/main.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples-qt6/view/main.py
+++ b/python/examples-qt6/view/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/apireview/entrydelegate.py
+++ b/python/examples/apireview/entrydelegate.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/apireview/entrydialog.py
+++ b/python/examples/apireview/entrydialog.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/apireview/main.py
+++ b/python/examples/apireview/main.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/apireview/mainwindow.py
+++ b/python/examples/apireview/mainwindow.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/apireview/ui_entrydialog.py
+++ b/python/examples/apireview/ui_entrydialog.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/apireview/ui_mainwindow.py
+++ b/python/examples/apireview/ui_mainwindow.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/customconstraints/main.py
+++ b/python/examples/customconstraints/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/gfxview/main.py
+++ b/python/examples/gfxview/main.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/headers/main.py
+++ b/python/examples/headers/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/listview/main.py
+++ b/python/examples/listview/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/reorder/main.py
+++ b/python/examples/reorder/main.py
@@ -3,7 +3,7 @@
 #
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/examples/view/main.py
+++ b/python/examples/view/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/tests/config.py.cmake
+++ b/python/tests/config.py.cmake
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/python/tests/tst_importModule.py
+++ b/python/tests/tst_importModule.py
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/AttributesModel/CMakeLists.txt
+++ b/qtests/AttributesModel/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/AttributesModel/main.cpp
+++ b/qtests/AttributesModel/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/AxisOwnership/CMakeLists.txt
+++ b/qtests/AxisOwnership/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/AxisOwnership/main.cpp
+++ b/qtests/AxisOwnership/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/BarDiagrams/CMakeLists.txt
+++ b/qtests/BarDiagrams/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/BarDiagrams/main.cpp
+++ b/qtests/BarDiagrams/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/CMakeLists.txt
+++ b/qtests/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/CartesianDiagramDataCompressor/CMakeLists.txt
+++ b/qtests/CartesianDiagramDataCompressor/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/CartesianDiagramDataCompressor/CartesianDiagramDataCompressorTests.cpp
+++ b/qtests/CartesianDiagramDataCompressor/CartesianDiagramDataCompressorTests.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/CartesianPlanes/CMakeLists.txt
+++ b/qtests/CartesianPlanes/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/CartesianPlanes/main.cpp
+++ b/qtests/CartesianPlanes/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ChartElementOwnership/CMakeLists.txt
+++ b/qtests/ChartElementOwnership/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/ChartElementOwnership/main.cpp
+++ b/qtests/ChartElementOwnership/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/Cloning/CMakeLists.txt
+++ b/qtests/Cloning/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/Cloning/main.cpp
+++ b/qtests/Cloning/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/DrawIntoPainter/CMakeLists.txt
+++ b/qtests/DrawIntoPainter/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/DrawIntoPainter/framewidget.cpp
+++ b/qtests/DrawIntoPainter/framewidget.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/DrawIntoPainter/framewidget.h
+++ b/qtests/DrawIntoPainter/framewidget.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/DrawIntoPainter/main.cpp
+++ b/qtests/DrawIntoPainter/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/DrawIntoPainter/mainwindow.cpp
+++ b/qtests/DrawIntoPainter/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/DrawIntoPainter/mainwindow.h
+++ b/qtests/DrawIntoPainter/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/Legends/CMakeLists.txt
+++ b/qtests/Legends/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/Legends/main.cpp
+++ b/qtests/Legends/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/LineDiagrams/CMakeLists.txt
+++ b/qtests/LineDiagrams/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/LineDiagrams/main.cpp
+++ b/qtests/LineDiagrams/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/Measure/CMakeLists.txt
+++ b/qtests/Measure/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/Measure/main.cpp
+++ b/qtests/Measure/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/Palette/CMakeLists.txt
+++ b/qtests/Palette/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/Palette/main.cpp
+++ b/qtests/Palette/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ParamVsParam/CMakeLists.txt
+++ b/qtests/ParamVsParam/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/ParamVsParam/ModelParamVsParam.cpp
+++ b/qtests/ParamVsParam/ModelParamVsParam.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ParamVsParam/ModelParamVsParam.h
+++ b/qtests/ParamVsParam/ModelParamVsParam.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ParamVsParam/ModelParamVsParamPlot.cpp
+++ b/qtests/ParamVsParam/ModelParamVsParamPlot.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ParamVsParam/ModelParamVsParamPlot.h
+++ b/qtests/ParamVsParam/ModelParamVsParamPlot.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ParamVsParam/main.cpp
+++ b/qtests/ParamVsParam/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ParamVsParam/mainwindow.cpp
+++ b/qtests/ParamVsParam/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/ParamVsParam/mainwindow.h
+++ b/qtests/ParamVsParam/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/PieDiagrams/CMakeLists.txt
+++ b/qtests/PieDiagrams/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/PieDiagrams/main.cpp
+++ b/qtests/PieDiagrams/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/PolarDiagrams/CMakeLists.txt
+++ b/qtests/PolarDiagrams/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/PolarDiagrams/main.cpp
+++ b/qtests/PolarDiagrams/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/PolarPlanes/CMakeLists.txt
+++ b/qtests/PolarPlanes/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/PolarPlanes/main.cpp
+++ b/qtests/PolarPlanes/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/QLayout/CMakeLists.txt
+++ b/qtests/QLayout/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/QLayout/main.cpp
+++ b/qtests/QLayout/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/RelativePosition/CMakeLists.txt
+++ b/qtests/RelativePosition/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/RelativePosition/main.cpp
+++ b/qtests/RelativePosition/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/qtests/WidgetElementOwnership/CMakeLists.txt
+++ b/qtests/WidgetElementOwnership/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qtests/WidgetElementOwnership/main.cpp
+++ b/qtests/WidgetElementOwnership/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/scripts/genignore.py
+++ b/scripts/genignore.py
@@ -2,7 +2,7 @@
 
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/KDChart/Cartesian/CartesianCoordinateTransformation.h
+++ b/src/KDChart/Cartesian/CartesianCoordinateTransformation.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalBarDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalBarDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalBarDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalBarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLineDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLyingBarDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLyingBarDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLyingBarDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalLyingBarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalPlotter_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalPlotter_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalPlotter_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartNormalPlotter_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentBarDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentBarDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentBarDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentBarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLineDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLineDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLineDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLyingBarDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLyingBarDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLyingBarDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentLyingBarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentPlotter_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentPlotter_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentPlotter_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartPercentPlotter_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedBarDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedBarDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedBarDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedBarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLineDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLineDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLineDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLyingBarDiagram_p.cpp
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLyingBarDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLyingBarDiagram_p.h
+++ b/src/KDChart/Cartesian/DiagramFlavors/KDChartStackedLyingBarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartAbstractCartesianDiagram.cpp
+++ b/src/KDChart/Cartesian/KDChartAbstractCartesianDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartAbstractCartesianDiagram.h
+++ b/src/KDChart/Cartesian/KDChartAbstractCartesianDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartAbstractCartesianDiagram_p.h
+++ b/src/KDChart/Cartesian/KDChartAbstractCartesianDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartBarAttributes.cpp
+++ b/src/KDChart/Cartesian/KDChartBarAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartBarAttributes.h
+++ b/src/KDChart/Cartesian/KDChartBarAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartBarDiagram.cpp
+++ b/src/KDChart/Cartesian/KDChartBarDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartBarDiagram.h
+++ b/src/KDChart/Cartesian/KDChartBarDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartBarDiagram_p.cpp
+++ b/src/KDChart/Cartesian/KDChartBarDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartBarDiagram_p.h
+++ b/src/KDChart/Cartesian/KDChartBarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianAxis.cpp
+++ b/src/KDChart/Cartesian/KDChartCartesianAxis.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianAxis.h
+++ b/src/KDChart/Cartesian/KDChartCartesianAxis.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianAxis_p.h
+++ b/src/KDChart/Cartesian/KDChartCartesianAxis_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane.cpp
+++ b/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane.h
+++ b/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane_p.h
+++ b/src/KDChart/Cartesian/KDChartCartesianCoordinatePlane_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianDiagramDataCompressor_p.cpp
+++ b/src/KDChart/Cartesian/KDChartCartesianDiagramDataCompressor_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianDiagramDataCompressor_p.h
+++ b/src/KDChart/Cartesian/KDChartCartesianDiagramDataCompressor_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianGrid.cpp
+++ b/src/KDChart/Cartesian/KDChartCartesianGrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartCartesianGrid.h
+++ b/src/KDChart/Cartesian/KDChartCartesianGrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsAxis.cpp
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsAxis.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsAxis.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsAxis.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsAxis_p.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsAxis_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsCoordinatePlane.cpp
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsCoordinatePlane.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsCoordinatePlane.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsCoordinatePlane.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsCoordinatePlane_p.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsCoordinatePlane_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram.cpp
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram_p.cpp
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram_p.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsGrid.cpp
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsGrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsGrid.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsGrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsGridAttributes.cpp
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsGridAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLeveyJenningsGridAttributes.h
+++ b/src/KDChart/Cartesian/KDChartLeveyJenningsGridAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLineDiagram.cpp
+++ b/src/KDChart/Cartesian/KDChartLineDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLineDiagram.h
+++ b/src/KDChart/Cartesian/KDChartLineDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLineDiagram_p.cpp
+++ b/src/KDChart/Cartesian/KDChartLineDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartLineDiagram_p.h
+++ b/src/KDChart/Cartesian/KDChartLineDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartPlotter.cpp
+++ b/src/KDChart/Cartesian/KDChartPlotter.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartPlotter.h
+++ b/src/KDChart/Cartesian/KDChartPlotter.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartPlotterDiagramCompressor.cpp
+++ b/src/KDChart/Cartesian/KDChartPlotterDiagramCompressor.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartPlotterDiagramCompressor.h
+++ b/src/KDChart/Cartesian/KDChartPlotterDiagramCompressor.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartPlotterDiagramCompressor_p.h
+++ b/src/KDChart/Cartesian/KDChartPlotterDiagramCompressor_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartPlotter_p.cpp
+++ b/src/KDChart/Cartesian/KDChartPlotter_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartPlotter_p.h
+++ b/src/KDChart/Cartesian/KDChartPlotter_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartStockBarAttributes.cpp
+++ b/src/KDChart/Cartesian/KDChartStockBarAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartStockBarAttributes.h
+++ b/src/KDChart/Cartesian/KDChartStockBarAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartStockDiagram.cpp
+++ b/src/KDChart/Cartesian/KDChartStockDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartStockDiagram.h
+++ b/src/KDChart/Cartesian/KDChartStockDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartStockDiagram_p.cpp
+++ b/src/KDChart/Cartesian/KDChartStockDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartStockDiagram_p.h
+++ b/src/KDChart/Cartesian/KDChartStockDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartThreeDBarAttributes.cpp
+++ b/src/KDChart/Cartesian/KDChartThreeDBarAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartThreeDBarAttributes.h
+++ b/src/KDChart/Cartesian/KDChartThreeDBarAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/KDChartThreeDBarAttributes_p.h
+++ b/src/KDChart/Cartesian/KDChartThreeDBarAttributes_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/PaintingHelpers_p.cpp
+++ b/src/KDChart/Cartesian/PaintingHelpers_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Cartesian/PaintingHelpers_p.h
+++ b/src/KDChart/Cartesian/PaintingHelpers_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/ChartGraphicsItem.cpp
+++ b/src/KDChart/ChartGraphicsItem.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/ChartGraphicsItem.h
+++ b/src/KDChart/ChartGraphicsItem.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractArea.cpp
+++ b/src/KDChart/KDChartAbstractArea.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractArea.h
+++ b/src/KDChart/KDChartAbstractArea.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAreaBase.cpp
+++ b/src/KDChart/KDChartAbstractAreaBase.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAreaBase.h
+++ b/src/KDChart/KDChartAbstractAreaBase.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAreaBase_p.h
+++ b/src/KDChart/KDChartAbstractAreaBase_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAreaWidget.cpp
+++ b/src/KDChart/KDChartAbstractAreaWidget.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAreaWidget.h
+++ b/src/KDChart/KDChartAbstractAreaWidget.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAreaWidget_p.h
+++ b/src/KDChart/KDChartAbstractAreaWidget_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractArea_p.h
+++ b/src/KDChart/KDChartAbstractArea_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAxis.cpp
+++ b/src/KDChart/KDChartAbstractAxis.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAxis.h
+++ b/src/KDChart/KDChartAbstractAxis.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractAxis_p.h
+++ b/src/KDChart/KDChartAbstractAxis_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractCoordinatePlane.cpp
+++ b/src/KDChart/KDChartAbstractCoordinatePlane.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractCoordinatePlane.h
+++ b/src/KDChart/KDChartAbstractCoordinatePlane.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractCoordinatePlane_p.h
+++ b/src/KDChart/KDChartAbstractCoordinatePlane_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractDiagram.cpp
+++ b/src/KDChart/KDChartAbstractDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractDiagram.h
+++ b/src/KDChart/KDChartAbstractDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractDiagram_p.cpp
+++ b/src/KDChart/KDChartAbstractDiagram_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractDiagram_p.h
+++ b/src/KDChart/KDChartAbstractDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractGrid.cpp
+++ b/src/KDChart/KDChartAbstractGrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractGrid.h
+++ b/src/KDChart/KDChartAbstractGrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractProxyModel.cpp
+++ b/src/KDChart/KDChartAbstractProxyModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractProxyModel.h
+++ b/src/KDChart/KDChartAbstractProxyModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractThreeDAttributes.cpp
+++ b/src/KDChart/KDChartAbstractThreeDAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractThreeDAttributes.h
+++ b/src/KDChart/KDChartAbstractThreeDAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAbstractThreeDAttributes_p.h
+++ b/src/KDChart/KDChartAbstractThreeDAttributes_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAttributesModel.cpp
+++ b/src/KDChart/KDChartAttributesModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartAttributesModel.h
+++ b/src/KDChart/KDChartAttributesModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartBackgroundAttributes.cpp
+++ b/src/KDChart/KDChartBackgroundAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartBackgroundAttributes.h
+++ b/src/KDChart/KDChartBackgroundAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartChart.cpp
+++ b/src/KDChart/KDChartChart.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartChart.h
+++ b/src/KDChart/KDChartChart.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartChart_p.h
+++ b/src/KDChart/KDChartChart_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDataValueAttributes.cpp
+++ b/src/KDChart/KDChartDataValueAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDataValueAttributes.h
+++ b/src/KDChart/KDChartDataValueAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDatasetProxyModel.cpp
+++ b/src/KDChart/KDChartDatasetProxyModel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDatasetProxyModel.h
+++ b/src/KDChart/KDChartDatasetProxyModel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDatasetSelector.cpp
+++ b/src/KDChart/KDChartDatasetSelector.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDatasetSelector.h
+++ b/src/KDChart/KDChartDatasetSelector.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDiagramObserver.cpp
+++ b/src/KDChart/KDChartDiagramObserver.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartDiagramObserver.h
+++ b/src/KDChart/KDChartDiagramObserver.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartEnums.h
+++ b/src/KDChart/KDChartEnums.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartFrameAttributes.cpp
+++ b/src/KDChart/KDChartFrameAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartFrameAttributes.h
+++ b/src/KDChart/KDChartFrameAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartGlobal.h
+++ b/src/KDChart/KDChartGlobal.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartGridAttributes.cpp
+++ b/src/KDChart/KDChartGridAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartGridAttributes.h
+++ b/src/KDChart/KDChartGridAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartHeaderFooter.cpp
+++ b/src/KDChart/KDChartHeaderFooter.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartHeaderFooter.h
+++ b/src/KDChart/KDChartHeaderFooter.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartHeaderFooter_p.h
+++ b/src/KDChart/KDChartHeaderFooter_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartLayoutItems.cpp
+++ b/src/KDChart/KDChartLayoutItems.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartLayoutItems.h
+++ b/src/KDChart/KDChartLayoutItems.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartLegend.cpp
+++ b/src/KDChart/KDChartLegend.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartLegend.h
+++ b/src/KDChart/KDChartLegend.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartLegend_p.h
+++ b/src/KDChart/KDChartLegend_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartLineAttributes.cpp
+++ b/src/KDChart/KDChartLineAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartLineAttributes.h
+++ b/src/KDChart/KDChartLineAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartMarkerAttributes.cpp
+++ b/src/KDChart/KDChartMarkerAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartMarkerAttributes.h
+++ b/src/KDChart/KDChartMarkerAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartMeasure.cpp
+++ b/src/KDChart/KDChartMeasure.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartMeasure.h
+++ b/src/KDChart/KDChartMeasure.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartModelDataCache_p.cpp
+++ b/src/KDChart/KDChartModelDataCache_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartModelDataCache_p.h
+++ b/src/KDChart/KDChartModelDataCache_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartNullPaintDevice.h
+++ b/src/KDChart/KDChartNullPaintDevice.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPaintContext.cpp
+++ b/src/KDChart/KDChartPaintContext.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPaintContext.h
+++ b/src/KDChart/KDChartPaintContext.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPainterSaver_p.h
+++ b/src/KDChart/KDChartPainterSaver_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPalette.cpp
+++ b/src/KDChart/KDChartPalette.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPalette.h
+++ b/src/KDChart/KDChartPalette.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPosition.cpp
+++ b/src/KDChart/KDChartPosition.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPosition.h
+++ b/src/KDChart/KDChartPosition.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPrintingParameters.cpp
+++ b/src/KDChart/KDChartPrintingParameters.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartPrintingParameters.h
+++ b/src/KDChart/KDChartPrintingParameters.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartRelativePosition.cpp
+++ b/src/KDChart/KDChartRelativePosition.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartRelativePosition.h
+++ b/src/KDChart/KDChartRelativePosition.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartRulerAttributes.cpp
+++ b/src/KDChart/KDChartRulerAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartRulerAttributes.h
+++ b/src/KDChart/KDChartRulerAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartTextArea.cpp
+++ b/src/KDChart/KDChartTextArea.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartTextArea.h
+++ b/src/KDChart/KDChartTextArea.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartTextArea_p.h
+++ b/src/KDChart/KDChartTextArea_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartTextAttributes.cpp
+++ b/src/KDChart/KDChartTextAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartTextAttributes.h
+++ b/src/KDChart/KDChartTextAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartTextLabelCache.cpp
+++ b/src/KDChart/KDChartTextLabelCache.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartTextLabelCache.h
+++ b/src/KDChart/KDChartTextLabelCache.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartThreeDLineAttributes.cpp
+++ b/src/KDChart/KDChartThreeDLineAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartThreeDLineAttributes.h
+++ b/src/KDChart/KDChartThreeDLineAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartThreeDLineAttributes_p.h
+++ b/src/KDChart/KDChartThreeDLineAttributes_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartValueTrackerAttributes.cpp
+++ b/src/KDChart/KDChartValueTrackerAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartValueTrackerAttributes.h
+++ b/src/KDChart/KDChartValueTrackerAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartWidget.cpp
+++ b/src/KDChart/KDChartWidget.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartWidget.h
+++ b/src/KDChart/KDChartWidget.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartWidget_p.h
+++ b/src/KDChart/KDChartWidget_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDChartZoomParameters.h
+++ b/src/KDChart/KDChartZoomParameters.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDTextDocument.cpp
+++ b/src/KDChart/KDTextDocument.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/KDTextDocument.h
+++ b/src/KDChart/KDTextDocument.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartAbstractPieDiagram.cpp
+++ b/src/KDChart/Polar/KDChartAbstractPieDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartAbstractPieDiagram.h
+++ b/src/KDChart/Polar/KDChartAbstractPieDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartAbstractPieDiagram_p.h
+++ b/src/KDChart/Polar/KDChartAbstractPieDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartAbstractPolarDiagram.cpp
+++ b/src/KDChart/Polar/KDChartAbstractPolarDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartAbstractPolarDiagram.h
+++ b/src/KDChart/Polar/KDChartAbstractPolarDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartAbstractPolarDiagram_p.h
+++ b/src/KDChart/Polar/KDChartAbstractPolarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPieAttributes.cpp
+++ b/src/KDChart/Polar/KDChartPieAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPieAttributes.h
+++ b/src/KDChart/Polar/KDChartPieAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPieAttributes_p.h
+++ b/src/KDChart/Polar/KDChartPieAttributes_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPieDiagram.cpp
+++ b/src/KDChart/Polar/KDChartPieDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPieDiagram.h
+++ b/src/KDChart/Polar/KDChartPieDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPieDiagram_p.h
+++ b/src/KDChart/Polar/KDChartPieDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarCoordinatePlane.cpp
+++ b/src/KDChart/Polar/KDChartPolarCoordinatePlane.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarCoordinatePlane.h
+++ b/src/KDChart/Polar/KDChartPolarCoordinatePlane.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarCoordinatePlane_p.h
+++ b/src/KDChart/Polar/KDChartPolarCoordinatePlane_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarDiagram.cpp
+++ b/src/KDChart/Polar/KDChartPolarDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarDiagram.h
+++ b/src/KDChart/Polar/KDChartPolarDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarDiagram_p.h
+++ b/src/KDChart/Polar/KDChartPolarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarGrid.cpp
+++ b/src/KDChart/Polar/KDChartPolarGrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartPolarGrid.h
+++ b/src/KDChart/Polar/KDChartPolarGrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarCoordinatePlane.cpp
+++ b/src/KDChart/Polar/KDChartRadarCoordinatePlane.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarCoordinatePlane.h
+++ b/src/KDChart/Polar/KDChartRadarCoordinatePlane.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarCoordinatePlane_p.h
+++ b/src/KDChart/Polar/KDChartRadarCoordinatePlane_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarDiagram.cpp
+++ b/src/KDChart/Polar/KDChartRadarDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarDiagram.h
+++ b/src/KDChart/Polar/KDChartRadarDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarDiagram_p.h
+++ b/src/KDChart/Polar/KDChartRadarDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarGrid.cpp
+++ b/src/KDChart/Polar/KDChartRadarGrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRadarGrid.h
+++ b/src/KDChart/Polar/KDChartRadarGrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRingDiagram.cpp
+++ b/src/KDChart/Polar/KDChartRingDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRingDiagram.h
+++ b/src/KDChart/Polar/KDChartRingDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartRingDiagram_p.h
+++ b/src/KDChart/Polar/KDChartRingDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartThreeDPieAttributes.cpp
+++ b/src/KDChart/Polar/KDChartThreeDPieAttributes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartThreeDPieAttributes.h
+++ b/src/KDChart/Polar/KDChartThreeDPieAttributes.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Polar/KDChartThreeDPieAttributes_p.h
+++ b/src/KDChart/Polar/KDChartThreeDPieAttributes_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/ReverseMapper.cpp
+++ b/src/KDChart/ReverseMapper.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/ReverseMapper.h
+++ b/src/KDChart/ReverseMapper.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartAbstractTernaryDiagram.cpp
+++ b/src/KDChart/Ternary/KDChartAbstractTernaryDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartAbstractTernaryDiagram.h
+++ b/src/KDChart/Ternary/KDChartAbstractTernaryDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartAbstractTernaryDiagram_p.h
+++ b/src/KDChart/Ternary/KDChartAbstractTernaryDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryAxis.cpp
+++ b/src/KDChart/Ternary/KDChartTernaryAxis.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryAxis.h
+++ b/src/KDChart/Ternary/KDChartTernaryAxis.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryCoordinatePlane.cpp
+++ b/src/KDChart/Ternary/KDChartTernaryCoordinatePlane.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryCoordinatePlane.h
+++ b/src/KDChart/Ternary/KDChartTernaryCoordinatePlane.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryCoordinatePlane_p.h
+++ b/src/KDChart/Ternary/KDChartTernaryCoordinatePlane_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryGrid.cpp
+++ b/src/KDChart/Ternary/KDChartTernaryGrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryGrid.h
+++ b/src/KDChart/Ternary/KDChartTernaryGrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryLineDiagram.cpp
+++ b/src/KDChart/Ternary/KDChartTernaryLineDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryLineDiagram.h
+++ b/src/KDChart/Ternary/KDChartTernaryLineDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryLineDiagram_p.h
+++ b/src/KDChart/Ternary/KDChartTernaryLineDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryPointDiagram.cpp
+++ b/src/KDChart/Ternary/KDChartTernaryPointDiagram.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryPointDiagram.h
+++ b/src/KDChart/Ternary/KDChartTernaryPointDiagram.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/KDChartTernaryPointDiagram_p.h
+++ b/src/KDChart/Ternary/KDChartTernaryPointDiagram_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/TernaryConstants.cpp
+++ b/src/KDChart/Ternary/TernaryConstants.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/TernaryConstants.h
+++ b/src/KDChart/Ternary/TernaryConstants.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/TernaryPoint.cpp
+++ b/src/KDChart/Ternary/TernaryPoint.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/Ternary/TernaryPoint.h
+++ b/src/KDChart/Ternary/TernaryPoint.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChart/kdchart_export.h
+++ b/src/KDChart/kdchart_export.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDChartConfig.cmake.in
+++ b/src/KDChartConfig.cmake.in
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/KDGantt/kdganttabstractgrid.cpp
+++ b/src/KDGantt/kdganttabstractgrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttabstractgrid.h
+++ b/src/KDGantt/kdganttabstractgrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttabstractgrid_p.h
+++ b/src/KDGantt/kdganttabstractgrid_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttabstractrowcontroller.cpp
+++ b/src/KDGantt/kdganttabstractrowcontroller.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttabstractrowcontroller.h
+++ b/src/KDGantt/kdganttabstractrowcontroller.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraint.cpp
+++ b/src/KDGantt/kdganttconstraint.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraint.h
+++ b/src/KDGantt/kdganttconstraint.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraint_p.h
+++ b/src/KDGantt/kdganttconstraint_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraintgraphicsitem.cpp
+++ b/src/KDGantt/kdganttconstraintgraphicsitem.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraintgraphicsitem.h
+++ b/src/KDGantt/kdganttconstraintgraphicsitem.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraintmodel.cpp
+++ b/src/KDGantt/kdganttconstraintmodel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraintmodel.h
+++ b/src/KDGantt/kdganttconstraintmodel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraintmodel_p.h
+++ b/src/KDGantt/kdganttconstraintmodel_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraintproxy.cpp
+++ b/src/KDGantt/kdganttconstraintproxy.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttconstraintproxy.h
+++ b/src/KDGantt/kdganttconstraintproxy.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttdatetimegrid.cpp
+++ b/src/KDGantt/kdganttdatetimegrid.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttdatetimegrid.h
+++ b/src/KDGantt/kdganttdatetimegrid.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttdatetimegrid_p.h
+++ b/src/KDGantt/kdganttdatetimegrid_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttforwardingproxymodel.cpp
+++ b/src/KDGantt/kdganttforwardingproxymodel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttforwardingproxymodel.h
+++ b/src/KDGantt/kdganttforwardingproxymodel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttglobal.cpp
+++ b/src/KDGantt/kdganttglobal.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttglobal.h
+++ b/src/KDGantt/kdganttglobal.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsitem.cpp
+++ b/src/KDGantt/kdganttgraphicsitem.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsitem.h
+++ b/src/KDGantt/kdganttgraphicsitem.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsscene.cpp
+++ b/src/KDGantt/kdganttgraphicsscene.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsscene.h
+++ b/src/KDGantt/kdganttgraphicsscene.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsscene_p.h
+++ b/src/KDGantt/kdganttgraphicsscene_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsview.cpp
+++ b/src/KDGantt/kdganttgraphicsview.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsview.h
+++ b/src/KDGantt/kdganttgraphicsview.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttgraphicsview_p.h
+++ b/src/KDGantt/kdganttgraphicsview_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttitemdelegate.cpp
+++ b/src/KDGantt/kdganttitemdelegate.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttitemdelegate.h
+++ b/src/KDGantt/kdganttitemdelegate.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttitemdelegate_p.h
+++ b/src/KDGantt/kdganttitemdelegate_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttlegend.cpp
+++ b/src/KDGantt/kdganttlegend.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttlegend.h
+++ b/src/KDGantt/kdganttlegend.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttlegend_p.h
+++ b/src/KDGantt/kdganttlegend_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttlistviewrowcontroller.cpp
+++ b/src/KDGantt/kdganttlistviewrowcontroller.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttlistviewrowcontroller.h
+++ b/src/KDGantt/kdganttlistviewrowcontroller.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttlistviewrowcontroller_p.h
+++ b/src/KDGantt/kdganttlistviewrowcontroller_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttproxymodel.cpp
+++ b/src/KDGantt/kdganttproxymodel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttproxymodel.h
+++ b/src/KDGantt/kdganttproxymodel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttproxymodel_p.h
+++ b/src/KDGantt/kdganttproxymodel_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttstyleoptionganttitem.cpp
+++ b/src/KDGantt/kdganttstyleoptionganttitem.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttstyleoptionganttitem.h
+++ b/src/KDGantt/kdganttstyleoptionganttitem.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttsummaryhandlingproxymodel.cpp
+++ b/src/KDGantt/kdganttsummaryhandlingproxymodel.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttsummaryhandlingproxymodel.h
+++ b/src/KDGantt/kdganttsummaryhandlingproxymodel.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttsummaryhandlingproxymodel_p.h
+++ b/src/KDGantt/kdganttsummaryhandlingproxymodel_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdgantttreeviewrowcontroller.cpp
+++ b/src/KDGantt/kdgantttreeviewrowcontroller.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdgantttreeviewrowcontroller.h
+++ b/src/KDGantt/kdgantttreeviewrowcontroller.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdgantttreeviewrowcontroller_p.h
+++ b/src/KDGantt/kdgantttreeviewrowcontroller_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttview.cpp
+++ b/src/KDGantt/kdganttview.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttview.h
+++ b/src/KDGantt/kdganttview.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/kdganttview_p.h
+++ b/src/KDGantt/kdganttview_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/unittest/libutil.h
+++ b/src/KDGantt/unittest/libutil.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/unittest/test.cpp
+++ b/src/KDGantt/unittest/test.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/unittest/test.h
+++ b/src/KDGantt/unittest/test.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/unittest/testregistry.cpp
+++ b/src/KDGantt/unittest/testregistry.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDGantt/unittest/testregistry.h
+++ b/src/KDGantt/unittest/testregistry.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/DelayedData/CMakeLists.txt
+++ b/tests/DelayedData/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/DelayedData/main.cpp
+++ b/tests/DelayedData/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/apireview/CMakeLists.txt
+++ b/tests/Gantt/apireview/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/apireview/entrydelegate.cpp
+++ b/tests/Gantt/apireview/entrydelegate.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/apireview/entrydelegate.h
+++ b/tests/Gantt/apireview/entrydelegate.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/apireview/entrydialog.cpp
+++ b/tests/Gantt/apireview/entrydialog.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/apireview/entrydialog.h
+++ b/tests/Gantt/apireview/entrydialog.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/apireview/main.cpp
+++ b/tests/Gantt/apireview/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/apireview/mainwindow.cpp
+++ b/tests/Gantt/apireview/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/apireview/mainwindow.h
+++ b/tests/Gantt/apireview/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/customconstraints/CMakeLists.txt
+++ b/tests/Gantt/customconstraints/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/customconstraints/main.cpp
+++ b/tests/Gantt/customconstraints/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/gfxview/CMakeLists.txt
+++ b/tests/Gantt/gfxview/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/gfxview/main.cpp
+++ b/tests/Gantt/gfxview/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/headers/CMakeLists.txt
+++ b/tests/Gantt/headers/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/headers/main.cpp
+++ b/tests/Gantt/headers/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/listview/CMakeLists.txt
+++ b/tests/Gantt/listview/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/listview/main.cpp
+++ b/tests/Gantt/listview/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/reorder/CMakeLists.txt
+++ b/tests/Gantt/reorder/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/reorder/main.cpp
+++ b/tests/Gantt/reorder/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/unittest/CMakeLists.txt
+++ b/tests/Gantt/unittest/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/unittest/main.cpp
+++ b/tests/Gantt/unittest/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/Gantt/view/CMakeLists.txt
+++ b/tests/Gantt/view/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/Gantt/view/main.cpp
+++ b/tests/Gantt/view/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/RootIndex/CMakeLists.txt
+++ b/tests/RootIndex/CMakeLists.txt
@@ -1,7 +1,6 @@
-##
 # This file is part of the KD Chart library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/RootIndex/main.cpp
+++ b/tests/RootIndex/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/RootIndex/mainwindow.cpp
+++ b/tests/RootIndex/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/tests/RootIndex/mainwindow.h
+++ b/tests/RootIndex/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Chart library.
 **
-** SPDX-FileCopyrightText: 2001-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2001 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **


### PR DESCRIPTION
For individual files: use year of file creation
For entire project:
  remove year from the statement
  use the © where feasible

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code