### PR TITLE
Build for Qt6 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 # -DKDChart_QT6=[true|false]
 #  Build against Qt6 rather than Qt5
-#  Default=false (Qt5 will be used even if Qt6 is available)
+#  Default=true
 #
 # -DKDChart_STATIC=[true|false]
 #  Build static versions of the libraries
@@ -78,7 +78,7 @@ set(${PROJECT_NAME}_SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
 
 include(FeatureSummary)
 
-option(${PROJECT_NAME}_QT6 "Build against Qt 6" OFF)
+option(${PROJECT_NAME}_QT6 "Build against Qt 6" ON)
 option(${PROJECT_NAME}_STATIC "Build statically" OFF)
 option(${PROJECT_NAME}_TESTS "Build the tests" OFF)
 option(${PROJECT_NAME}_EXAMPLES "Build the examples" ON)

--- a/distro/qt5-debian.rules
+++ b/distro/qt5-debian.rules
@@ -1,4 +1,4 @@
 #!/usr/bin/make -f
-DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_BUILD_TYPE=Release
+DEB_CMAKE_EXTRA_FLAGS = -DKDChart_QT6=False -DCMAKE_BUILD_TYPE=Release
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/cmake.mk

--- a/distro/qt5-kdchart.spec
+++ b/distro/qt5-kdchart.spec
@@ -51,7 +51,7 @@ develop programs using kdchart.
 %autosetup
 
 %build
-cmake . -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+cmake . -DCMAKE_INSTALL_PREFIX=/usr -DKDChart_QT6=False -DCMAKE_BUILD_TYPE=Release
 %__make %{?_smp_mflags}
 
 %post -p /sbin/ldconfig


### PR DESCRIPTION
If your Qt5 build broke, pass -DKDChart_QT6=OFF to CMake.