### PR TITLE
Fix KDGantt header being recreated on every cmake run

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,7 +192,6 @@ ecm_generate_headers(
     COMMON_HEADER
     KDGantt
 )
-configure_file("${CMAKE_CURRENT_BINARY_DIR}/KDChart/KDGantt" "${CMAKE_CURRENT_BINARY_DIR}/KDChart/kdgantt.h" COPYONLY)
 list(APPEND kdchart_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/KDChart/kdgantt.h")
 
 install(


### PR DESCRIPTION
COMMON_HEADER already takes care of creating it, no need to do it again with configure_file