### PR TITLE
Revert "Fix KDGantt header being recreated on every cmake run"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ ecm_generate_headers(
     COMMON_HEADER
     KDGantt
 )
+configure_file("${CMAKE_CURRENT_BINARY_DIR}/KDChart/KDGantt" "${CMAKE_CURRENT_BINARY_DIR}/KDChart/kdgantt.h" COPYONLY)
 list(APPEND kdchart_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/KDChart/kdgantt.h")
 
 install(


### PR DESCRIPTION
This reverts commit f6f7ff7580d90a678dd6755e0d75e07b1d88e465, which was written after misreading the line being removed (that line copies KDGantt to kdgantt.h, not the other way around).

This commit fixes make install saying
file INSTALL cannot find
  "/kdab/src/kdchart/build_qt6_debug/src/KDChart/kdgantt.h": No such file or
  directory.