### PR TITLE
Fix one more NaN crash

### DIFF
--- a/src/KDChart/Cartesian/KDChartCartesianAxis.cpp
+++ b/src/KDChart/Cartesian/KDChartCartesianAxis.cpp
@@ -861,6 +861,8 @@ void CartesianAxis::paintCtx(PaintContext *context)
                 break;
             }
 
+            if (!qIsFinite(labelPos.x()) || !qIsFinite(labelPos.y()))
+                continue;
             tickLabel->setGeometry(QRect(labelPos.toPoint(), size.toSize()));
 
             if (step == Painting) {

--- a/src/KDChart/ReverseMapper.cpp
+++ b/src/KDChart/ReverseMapper.cpp
@@ -153,6 +153,8 @@ void ReverseMapper::addLine(int row, int column, const QPointF &from, const QPoi
     }
     const QPointF lineVector(right - left);
     const qreal lineVectorLength = sqrt(lineVector.x() * lineVector.x() + lineVector.y() * lineVector.y());
+    if (!qIsFinite(lineVectorLength) || qFuzzyIsNull(lineVectorLength))
+        return;
     const QPointF lineVectorUnit(lineVector / lineVectorLength);
     const QPointF normOfLineVectorUnit(-lineVectorUnit.y(), lineVectorUnit.x());
     // now the four polygon end points:


### PR DESCRIPTION
Qt 6.11 introduced an assert for converting QPointF to QPoint when either x or y is NaN. This fixes a few more issues relating to that.