### PR TITLE
ci: Fix CI with newer MSVC by removing the Qt5 workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,6 @@ jobs:
           #- static
 
         config:
-          - qt_version: 5.15.2
-            architectures: "x86_64"
-
           - qt_version: 6.9.0
             architectures: "x86_64;arm64"
 


### PR DESCRIPTION
Qt5 is now rotting and fails to build with recent MSVC:
   error C2653: 'stdext': is not a class or namespace name in qvector.h

KDChart will still build with Qt5 if you patch Qt, but there's probably 0 such users out there. Please upgrade to Qt6 or contact us for a patch.