### PR TITLE
ci: Fix the macOS and Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - windows-2022
           - macos-latest
 
         build_type:
@@ -37,8 +38,20 @@ jobs:
           - qt_version: 5.15.2
             architectures: "x86_64"
 
-          - qt_version: 6.9.0
+          - qt_version: 6.9.3
             architectures: "x86_64;arm64"
+
+        exclude:
+          # Qt 5.15.2 uses stdext::checked_array_iterator, which Visual Studio
+          # 2025 removed, so it only builds on the older image
+          - os: windows-latest
+            config:
+              qt_version: 5.15.2
+              architectures: "x86_64"
+          - os: windows-2022
+            config:
+              qt_version: 6.9.3
+              architectures: "x86_64;arm64"
 
         include:
           - os: ubuntu-22.04


### PR DESCRIPTION
CI has been red since early July. Both failures come from the runner images moving on, not from anything in KDChart.

**macOS** — `build (macos-latest, Debug, shared, 6.9.0)`:

```
ld: framework 'AGL' not found
```

Qt links QtGui against the AGL framework, and the SDK on `macos-latest` no longer ships it (QTBUG-137687). Qt removed that linkage in qtbase commit `cdb33c3d562`, which was backported and first released in **6.9.2** — two patch releases after the 6.9.0 we pin. Not backported to 6.8, so 6.9.2 or later is the minimum. This bumps the pin to 6.9.3.

**Windows** — `build (windows-latest, Debug, shared, 5.15.2)`:

```
Qt/5.15.2/msvc2019_64/include/QtCore/qvarlengtharray.h(553): error C2065: 'stdext': undeclared identifier
```

`windows-latest` is now Visual Studio 2025, whose STL removed the `stdext` extension that Qt 5.15.2 uses. That combination cannot be made to work and Qt 5.15.2 will not gain a fix, so Qt 5 moves to `windows-2022` (the same image KDReports pins) while Qt 6 stays on `windows-latest`, which is where new toolchain breakage actually shows up first.

Coverage moves rather than shrinking, and the job count is unchanged — 8 matrix combinations, 2 excluded, 6 kept plus the existing `include`, matching the 7 jobs of the last run:

| | before | after |
| --- | --- | --- |
| Qt 5.15.2 on Windows | windows-latest (failing) | windows-2022 |
| Qt 6 on Windows | windows-latest | windows-latest |
| Qt 6 on macOS | 6.9.0 (failing) | 6.9.3 |

One note for review: the `exclude` entries match both `qt_version` and `architectures` rather than `qt_version` alone. GitHub documents partial matching for excludes, but every other KDAB repo using this pattern excludes a `config` that has only one key, so nested partial matching is untested here — matching the full object is guaranteed to fire.
